### PR TITLE
Hiding loading gif on a per request method.

### DIFF
--- a/js/bulk_photo_nodes.js
+++ b/js/bulk_photo_nodes.js
@@ -10,7 +10,10 @@ jQuery(document).ready(function($) {
     .ajaxStart(function(){
       $(this).append('<div class="ajax-overlay" /><div class="ajax-progress-throbber" />')
     })
-    .ajaxStop(function () {
+    .ajaxComplete(function(){
+      $('.ajax-overlay, .ajax-progress-throbber', $(this)).remove();
+    })
+    .ajaxStop(function(){
       $('.ajax-overlay, .ajax-progress-throbber', $(this)).remove();
     });
 });


### PR DESCRIPTION
ajaxStop does not fire up for very long requests, especially for
requests that goes beyond timeout. Added ajaxComplete to add
reaction on a per request bases.
