### PR TITLE
PTPIHSR-30: Make sure the image filename is maintained.

### DIFF
--- a/bulk_photo_nodes.module
+++ b/bulk_photo_nodes.module
@@ -636,9 +636,16 @@ function bulk_photo_nodes_save_node($node_type, $node_fields, $node_overrides, &
   if ($options['directory'] == '/') {
     $options['directory'] = '';
   }
-  $destination = $options['scheme'] . $image_field->uid . '-' . $images_count . '.' . $extension;
-  $image_field->filename = $image_field->uid . '-' . $images_count . '.' . $extension;
-  $image_field_ref = (array) file_move($image_field, $destination, FILE_EXISTS_REPLACE);
+
+  // Allow to use the same filename, but update image information
+  // ONLY if image URI has changed.
+  $destination = $options['scheme'] . $image_field->filename;
+  if ($destination == $image_field->uri) {
+    $image_field_ref = $node->{$image_field_name}[LANGUAGE_NONE][0];
+  }
+  else {
+    $image_field_ref = (array) file_move($image_field, $destination, FILE_EXISTS_REPLACE);
+  }
 
   // Correctly set all fields for the node.
   $node = bulk_photo_nodes_prepare_fields($node_fields, $node, $node_overrides, $image_field_name);
@@ -1088,7 +1095,7 @@ function bulk_photo_nodes_field_add_more_js($form, $form_state) {
   $parents = $element['#field_parents'];
 
   if (empty($field_name)) {
-  	return;
+    return;
   }
 
   $field = field_info_field($field_name);

--- a/bulk_photo_nodes.module
+++ b/bulk_photo_nodes.module
@@ -640,11 +640,8 @@ function bulk_photo_nodes_save_node($node_type, $node_fields, $node_overrides, &
   // Allow to use the same filename, but update image information
   // ONLY if image URI has changed.
   $destination = $options['scheme'] . $image_field->filename;
-  if ($destination == $image_field->uri) {
-    $image_field_ref = $node->{$image_field_name}[LANGUAGE_NONE][0];
-  }
-  else {
-    $image_field_ref = (array) file_move($image_field, $destination, FILE_EXISTS_REPLACE);
+  if ($destination != $image_field->uri) {
+    $image_field_ref = (array) file_move($image_field, $destination);
   }
 
   // Correctly set all fields for the node.


### PR DESCRIPTION
Allow to use the same filename, but update image information
ONLY if image URI has changed.

Originally, the module changes the location and filename to [scheme]-[user-id]-[file-count-by-user].[extension] format, which is technically dirty and unwanted by client. Example: URI: public://1-1.jpg and filename 1-1.jpg.

The client does not want this behavior and wanted the filenames to be the same when it was uploaded.

The fix is to use the same filename instead of the format above. In addition, this module temporarily uploads the file to the public scheme thus it has to move the file to the correct scheme when saving on a per node basis. Not all file settings are in public.

So, I added a condition only to move the file if the temporary public location is not the same to the actual file scheme setting. If they are similar simply copy the temporary file array or file info. If not move to appropriate scheme.
